### PR TITLE
chore: build datatracker API client

### DIFF
--- a/client/openapitools.json
+++ b/client/openapitools.json
@@ -12,6 +12,15 @@
           "packageName": "rfced_www_client",
           "disallowAdditionalPropertiesIfNotPresent": false
         }
+      },
+      "datatracker": {
+        "generatorName": "typescript-fetch",
+        "inputSpec": "http://localhost:8000/api/v3/schema/",
+        "output": "#{cwd}/generated/datatracker_client",
+        "additionalProperties": {
+          "packageName": "datatracker_client",
+          "disallowAdditionalPropertiesIfNotPresent": false
+        }
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "story:build": "histoire build",
     "story:preview": "histoire preview --port 4567",
     "generate:api": "npx --no @openapitools/openapi-generator-cli generate",
+    "generate:api:datatracker": "npx --no @openapitools/openapi-generator-cli generate --generator-key datatracker",
     "generate:api:help": "npx --no @openapitools/openapi-generator-cli help",
     "test:story": "LOST_PIXEL_DISABLE_TELEMETRY=1 npx --no lost-pixel docker",
     "test:story:view": "npx --no -c 'vite dev ./visual-regression-viewer'",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "story:preview": "histoire preview --port 4567",
     "generate:api": "npx --no @openapitools/openapi-generator-cli generate",
     "generate:api:datatracker": "npx --no @openapitools/openapi-generator-cli generate --generator-key datatracker",
+    "generate:api:rfced_www": "npx --no @openapitools/openapi-generator-cli generate --generator-key rfced-www",
     "generate:api:help": "npx --no @openapitools/openapi-generator-cli help",
     "test:story": "LOST_PIXEL_DISABLE_TELEMETRY=1 npx --no lost-pixel docker",
     "test:story:view": "npx --no -c 'vite dev ./visual-regression-viewer'",


### PR DESCRIPTION
Assumes that a datatracker instance with the django-rest-framework API is running on `http://localhost:8000`. That will need some rethinking but this might be suitable for early dev work. At the very least, the URL for the schema is likely to change (the `/api/v3/` prefix is really just a placeholder)