### PR TITLE
chore: remove sepia, no one liked it

### DIFF
--- a/client/components/HeaderNavData.ts
+++ b/client/components/HeaderNavData.ts
@@ -7,7 +7,6 @@ export const colorPreferences = [
   { value: 'system', label: 'System default' },
   { value: 'light', label: 'Light' },
   { value: 'dark', label: 'Dark' },
-  { value: 'sepia', label: 'Sepia' }
 ]
 
 export const menuData: MenuItem[] = [


### PR DESCRIPTION
The theme picker has a default of 'Sepia' which no one (including me) liked so let's remove it.