### PR TITLE
feat: Feeds (RSS2, Atom1)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "@playwright/test": "^1.40.0",
         "@tailwindcss/forms": "^0.5.8",
         "apigen-ts": "^1.0.1",
+        "feed": "^4.2.2",
         "glob": "^11.0.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.5.0",
@@ -9877,6 +9878,18 @@
         }
       }
     },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -17632,7 +17645,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/saxes": {
@@ -21467,6 +21479,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "@playwright/test": "^1.40.0",
     "@tailwindcss/forms": "^0.5.8",
     "apigen-ts": "^1.0.1",
+    "feed": "^4.2.2",
     "glob": "^11.0.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.5.0",

--- a/client/server/routes/rfcatom.xml.ts
+++ b/client/server/routes/rfcatom.xml.ts
@@ -1,0 +1,9 @@
+import { getFeedForLatestRFCs } from '~/utilities/feed'
+
+export default defineEventHandler(async (event) => {
+  setResponseHeaders(event, {
+    'Content-Type': 'text/xml; charset=utf-8'
+  })
+  const feed = await getFeedForLatestRFCs(15)
+  return feed.atom1()
+})

--- a/client/server/routes/rfcrss.xml.ts
+++ b/client/server/routes/rfcrss.xml.ts
@@ -1,0 +1,9 @@
+import { getFeedForLatestRFCs } from '~/utilities/feed'
+
+export default defineEventHandler(async (event) => {
+  setResponseHeaders(event, {
+    'Content-Type': 'text/xml; charset=utf-8'
+  })
+  const feed = await getFeedForLatestRFCs(15)
+  return feed.rss2()
+})

--- a/client/utilities/feed.ts
+++ b/client/utilities/feed.ts
@@ -1,0 +1,51 @@
+import { Feed } from 'feed'
+import type { FeedOptions } from 'feed'
+import { ApiClient } from '~/generated/red-client'
+import { PUBLIC_SITE, PRIVATE_API_URL, rfcPathBuilder } from './url'
+
+type DocListArg = Parameters<ApiClient['red']['docList']>[0]
+
+export const getFeedForLatestRFCs = async (
+  numberOfRFCs: number,
+  feedOptions?: FeedOptions
+) => {
+  const redApi = new ApiClient({ baseUrl: PRIVATE_API_URL })
+
+  const docListArg: DocListArg = {}
+
+  docListArg.sort = ['-number'] // sort by latest RFC
+  docListArg.limit = numberOfRFCs
+
+  const response = await redApi.red.docList(docListArg)
+
+  const feed = new Feed({
+    title: 'Recent RFCs',
+    description: 'Recently published RFCs',
+    id: PUBLIC_SITE,
+    link: PUBLIC_SITE,
+    generator: 'https://www.npmjs.com/package/feed',
+    language: 'en-us', // optional, used only in RSS 2.0, possible values: http://www.w3.org/TR/REC-html40/struct/dirlang.html#langcodes
+    copyright: '',
+    ...(feedOptions ?? {}),
+    updated:
+      response.results.length > 0 ?
+        parseDateString(response.results[0].published)
+      : new Date()
+  })
+
+  response.results.forEach((rfcMetadata) => {
+    const url = `${PUBLIC_SITE}${rfcPathBuilder(`RFC${rfcMetadata.number}`)}`
+    feed.addItem({
+      title: `RFC ${rfcMetadata.number}: ${rfcMetadata.title}`,
+      link: url,
+      description: rfcMetadata.abstract,
+      date: parseDateString(rfcMetadata.published)
+    })
+  })
+
+  return feed
+}
+
+const parseDateString = (date: string): Date => {
+  return new Date(date)
+}

--- a/client/utilities/feed.ts
+++ b/client/utilities/feed.ts
@@ -1,7 +1,7 @@
 import { Feed } from 'feed'
 import type { FeedOptions } from 'feed'
-import { ApiClient } from '~/generated/red-client'
 import { PUBLIC_SITE, PRIVATE_API_URL, rfcPathBuilder } from './url'
+import { ApiClient } from '~/generated/red-client'
 
 type DocListArg = Parameters<ApiClient['red']['docList']>[0]
 

--- a/client/utilities/url.ts
+++ b/client/utilities/url.ts
@@ -1,7 +1,10 @@
 import type { Rfc } from '~/generated/red-client'
 import { parseRFCId } from '~/utilities/rfc'
 
+// FIXME: get from an environment variable
 export const PRIVATE_API_URL = 'http://localhost:8000/'
+
+export const PUBLIC_SITE = 'https://www.rfc-editor.org/'
 
 export const SEARCH_PATH = '/search/' as const
 


### PR DESCRIPTION
Feeds 
* [`/rfcrss.xml` RSS2](https://www.rfc-editor.org/rfcrss.xml)
* [`/rfcatom.xml` Atom1](https://www.rfc-editor.org/rfcatom.xml)

The generated feeds aren't identical as the feed generator uses `<![CDATA[]]>` escaping but compliant clients should be fine :shrug: 