### PR TITLE
feat: rfc index header/footer

### DIFF
--- a/client/components/RFCIndexPage.vue
+++ b/client/components/RFCIndexPage.vue
@@ -10,16 +10,33 @@
     </SectionHeader>
     <div class="container mx-auto mt-10">
       <p class="leading-6 mb-2 pl-5 md:p-0 md:w-1/2">
-        This file contains entries for all RFCs in numeric order. RFC entries
-        appear in this format:
+        <template v-if="props.rfcNumberLimit !== undefined">
+          <template v-if="props.sort === 'ascending'">
+            This page shows the first {{ props.rfcNumberLimit }} RFCs published.
+            Click <a :href="RFC_INDEX_ALL_ASCENDING">Show All</a> to get the
+            full list (ascending). RFCs are listed in this format:
+          </template>
+          <template v-else-if="props.sort === 'descending'">
+            This page shows the last {{ props.rfcNumberLimit }} RFCs published.
+            Click <a :href="RFC_INDEX_ALL_DESCENDING">Show All</a> to get the
+            full list (descending). RFCs are listed in this format:
+          </template>
+        </template>
+        <template v-else>
+          <template v-if="props.sort === 'ascending'">
+            This file contains entries for all RFCs in numeric order. RFC
+            entries appear in this format:
+          </template>
+          <template v-else-if="props.sort === 'descending'">
+            This file contains entries for all RFCs in reverse numeric order.
+            RFC entries appear in this format:
+          </template>
+        </template>
       </p>
-      <RFCIndexTable
-        :rfc-rows="exampleRfcInformations"
-        is-example
-      ></RFCIndexTable>
+      <RFCIndexTable :rfc-rows="exampleRfcInformations" is-example />
 
       <p>For example:</p>
-      <RFCIndexTable :rfc-rows="exampleRfcInformations"></RFCIndexTable>
+      <RFCIndexTable :rfc-rows="exampleRfcInformations" />
 
       <Heading level="2" class="mt-4 mb-2">Key to Entries</Heading>
       <ul class="list-disc ml-6">
@@ -76,7 +93,18 @@
       <Heading v-if="rfcs" level="2" style-level="1" class="mt-6 mb-3">
         RFC Index
       </Heading>
-      <RFCIndexTable v-if="rfcs" :rfc-rows="rfcRows"></RFCIndexTable>
+      <RFCIndexTable v-if="rfcs" :rfc-rows="rfcRows" />
+
+      <template v-if="props.rfcNumberLimit !== undefined">
+        <p class="pt-4">
+          <template v-if="props.sort === 'ascending'">
+            <a :href="RFC_INDEX_ALL_ASCENDING">Show All</a>
+          </template>
+          <template v-else-if="props.sort === 'descending'">
+            <a :href="RFC_INDEX_ALL_DESCENDING">Show All</a>
+          </template>
+        </p>
+      </template>
     </div>
   </div>
 </template>
@@ -89,6 +117,8 @@ import { rfcToRfcIndexRow } from '~/utilities/rfc-index-html'
 import {
   PRIVATE_API_URL,
   PUBLIC_SITE,
+  RFC_INDEX_ALL_ASCENDING,
+  RFC_INDEX_ALL_DESCENDING,
   infoRfcPathBuilder
 } from '~/utilities/url'
 
@@ -98,6 +128,16 @@ type Props = {
   rfcNumberLimit?: number
 }
 const props = defineProps<Props>()
+
+useSeoMeta({
+  title:
+    props.rfcNumberLimit === undefined ?
+      props.sort === 'ascending' ?
+        'RFC Index'
+      : 'RFC Index (descending)'
+    : props.sort === 'ascending' ? `RFC Index first ${props.rfcNumberLimit}`
+    : `RFC Index last ${props.rfcNumberLimit}`
+})
 
 const createdOn = DateTime.now().toFormat('d LLLL yyyy')
 const apiClient = new ApiClient({ baseUrl: PRIVATE_API_URL })

--- a/client/components/RFCIndexTable.vue
+++ b/client/components/RFCIndexTable.vue
@@ -34,7 +34,7 @@
             {{ rfcRow.number }}
           </a>
         </td>
-        <td class="p-1">
+        <td class="p-1 align-top">
           <p>
             <Renderable :val="rfcRow.information" />
           </p>

--- a/client/components/Table.vue
+++ b/client/components/Table.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="border-2 border-black">
+  <table class="border-2 border-black dark:border-white">
     <slot />
   </table>
 </template>

--- a/client/components/TableRow.vue
+++ b/client/components/TableRow.vue
@@ -1,5 +1,7 @@
 <template>
-  <tr class="even:bg-gray-50 odd:bg-white">
+  <tr
+    class="even:bg-gray-50 odd:bg-white dark:even:bg-gray-500 dark:odd:bg-black"
+  >
     <slot />
   </tr>
 </template>

--- a/client/utilities/markdown.test.ts
+++ b/client/utilities/markdown.test.ts
@@ -13,6 +13,7 @@ const contentPath = path.resolve(clientPath, 'content')
 
 test('Markdown links validation', async () => {
   // Unfortunately Nuxt Content's queryCollection can't run in tests only in server routes
+  // so we have to read the markdown files directly from the filesystem
   const markdownPaths = await globby('**/*.md', {
     cwd: contentPath
   })
@@ -30,16 +31,16 @@ test('Markdown links validation', async () => {
       href.startsWith('https://') ||
       href.startsWith('mailto:')
     ) {
-      // external links aren't validated
+      // external links, and mailto: links, are assumed to be valid
       return
     }
 
-    const pathname = new URL(href, 'http://localhost/').pathname // removes #hash link
+    const { pathname } = new URL(href, 'http://localhost/') // extract pathname to remove #hash
 
-    /**
-     * After we've extracted the pathname we can accept some URLs that are valid
-     */
     if (
+      /**
+       * Some valid paths
+       */
       pathname.endsWith('/') ||
       pathname.endsWith('.pdf') ||
       pathname.endsWith('.txt') ||

--- a/client/utilities/rfc-index-txt.ts
+++ b/client/utilities/rfc-index-txt.ts
@@ -71,7 +71,7 @@ export async function renderRfcIndexDotTxt({
     .map((_, index) => ' '.repeat(index))
 
   docListArg.sort = ['number'] // sort by earliest RFC number
-  docListArg.limit = 1000 // load RFC in chunks
+  docListArg.limit = 1000
 
   let offset = 0
 

--- a/client/utilities/url.ts
+++ b/client/utilities/url.ts
@@ -10,6 +10,14 @@ export const SEARCH_PATH = '/search/' as const
 
 export const SEARCH_API_PATH = '/api/search/' as const
 
+export const RFC_INDEX_ALL_ASCENDING = '/rfc-index/' as const
+
+export const RFC_INDEX_100_ASCENDING = '/rfc-index-100a/' as const
+
+export const RFC_INDEX_ALL_DESCENDING = '/rfc-index2/' as const
+
+export const RFC_INDEX_100_DESCENDING = '/rfc-index-100d/' as const
+
 export const infoRfcPathBuilder = (rfcId: string) => {
   const rfcParts = parseRFCId(rfcId)
 


### PR DESCRIPTION
* adds the header and footer content to the `/rfc-index*` HTML routes
* safety check on loop that queries API
* moves the markdown.test.ts file out of the markdown `content` directory because Nuxt was getting confused
* URL constants