### PR TITLE
feat: CurrQstats.txt placeholder

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -86,6 +86,10 @@ export default defineNuxtConfig({
       swr: oneDayInSeconds,
       prerender: true
     },
+    '/reports/CurrQstats.txt': {
+      swr: oneDayInSeconds,
+      prerender: true
+    },
     '/rfc/rfc**.json': {
       swr: oneDayInSeconds,
       prerender: false // there are too many RFCs to prerender them, but we can at least `swr: true` cache them

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "test:lint:fix": "eslint . --fix",
     "test:types": "npx nuxi typecheck",
     "test:unittests": "vitest run",
+    "test:unittests:watch": "vitest",
     "test:story": "npm run story:build && LOST_PIXEL_DISABLE_TELEMETRY=1 npx --no lost-pixel docker",
     "test:story:view": "npx --no -c 'vite dev ./visual-regression-viewer'",
     "test:story:approve": "npm run story:build && LOST_PIXEL_DISABLE_TELEMETRY=1 npx --no lost-pixel docker update",

--- a/client/server/routes/reports/CurrQstats.txt.ts
+++ b/client/server/routes/reports/CurrQstats.txt.ts
@@ -1,0 +1,15 @@
+import { ApiClient } from '~/generated/red-client'
+import { PRIVATE_API_URL } from '~/utilities/url'
+import { renderCurrQstatsDotTxt } from '~/utilities/CurrQstats-txt'
+
+export default defineEventHandler(async (event) => {
+  setResponseHeaders(event, {
+    'Content-Type': 'text/plain; charset=utf-8'
+  })
+
+  const redApi = new ApiClient({ baseUrl: PRIVATE_API_URL })
+  const result = await renderCurrQstatsDotTxt({
+    redApi
+  })
+  return result
+})

--- a/client/utilities/CurrQstats-txt.ts
+++ b/client/utilities/CurrQstats-txt.ts
@@ -1,0 +1,131 @@
+import type { ApiClient } from '~/generated/red-client'
+import type { TestHelperResponses } from './CurrQstats.txt.test'
+import { padStart } from 'lodash-es'
+
+type Props = {
+  redApi: ApiClient
+}
+const TABLE_OFFSET = '    '
+
+const getHeader = () => {
+  const date = new Date()
+  const createdOn = `${date.getFullYear()}-${padStart((date.getMonth() + 1).toString(), 2, '0')}-${padStart(date.getDate().toString(), 2, '0')}`
+
+  return `#### RFC Editor Queue Summary:  ${createdOn} ####
+
+${TABLE_OFFSET}State             total #       total #      Median Wks    Average Wks
+${TABLE_OFFSET}                  docs          pages        in state      in state\n`
+}
+
+export const renderCurrQstatsDotTxt = async (
+  {
+    // FIXME:
+    // Use redApi when the API is available
+    // redApi,
+  }: Props
+): Promise<string> => {
+  let txt = getHeader()
+
+  // FIXME: use proper shape from ApiClient when it's available
+  const queueSummaryResponse: TestHelperResponses['queueSummaryResponse'] = {
+    results: [
+      {
+        state: 'EDIT',
+        totalDocs: 68,
+        totalPages: 2550,
+        medianWeeksInState: 5.6,
+        averageWeeksInState: 7.6
+      },
+      {
+        state: 'RFC-EDITOR',
+        totalDocs: 5,
+        totalPages: 161,
+        medianWeeksInState: 0.9,
+        averageWeeksInState: 1.2
+      },
+      {
+        state: 'AUTH48',
+        totalDocs: 29,
+        totalPages: 1004,
+        medianWeeksInState: 3.7,
+        averageWeeksInState: 7.4
+      },
+      {
+        state: 'AUTH48-DONE',
+        totalDocs: 3,
+        totalPages: 35,
+        medianWeeksInState: 0.7,
+        averageWeeksInState: 0.7
+      },
+      {
+        state: 'AUTH',
+        totalDocs: 0,
+        totalPages: 0,
+        medianWeeksInState: 0,
+        averageWeeksInState: 0
+      },
+      {
+        state: 'IANA',
+        totalDocs: 0,
+        totalPages: 0,
+        medianWeeksInState: 0,
+        averageWeeksInState: 0
+      },
+      {
+        state: 'IESG',
+        totalDocs: 0,
+        totalPages: 0,
+        medianWeeksInState: 0,
+        averageWeeksInState: 0
+      },
+      {
+        state: 'REF',
+        totalDocs: 1,
+        totalPages: 57,
+        medianWeeksInState: 0,
+        averageWeeksInState: 1
+      },
+      {
+        state: 'MISSREF(1G)',
+        totalDocs: 18,
+        totalPages: 600,
+        medianWeeksInState: 51.5,
+        averageWeeksInState: 57.2
+      },
+      {
+        state: 'MISSREF(2G)',
+        totalDocs: 6,
+        totalPages: 401,
+        medianWeeksInState: 87.8,
+        averageWeeksInState: 85.29 // changed to test rounding
+      },
+      {
+        state: 'MISSREF(3G)',
+        totalDocs: 1,
+        totalPages: 29,
+        medianWeeksInState: 0,
+        averageWeeksInState: 85.69 // changed to test rounding
+      },
+      {
+        state: 'TI',
+        totalDocs: 0,
+        totalPages: 0,
+        medianWeeksInState: 0,
+        averageWeeksInState: 0
+      }
+    ],
+    stats: {
+      totalDocs: 131,
+      totalPages: 4837
+    }
+  }
+
+  for (let i = 0; i < queueSummaryResponse.results.length; i++) {
+    const result = queueSummaryResponse.results[i]
+    txt += `${TABLE_OFFSET}${result.state.padEnd(15, ' ')}${result.totalDocs.toFixed(0).padStart(10, ' ')}${result.totalPages.toFixed(0).padStart(15, ' ')}${result.medianWeeksInState.toFixed(1).padStart(15, ' ')}${result.averageWeeksInState.toFixed(1).padStart(15, ' ')}\n`
+  }
+
+  txt += `\n\nTotals:${queueSummaryResponse.stats.totalDocs.toFixed(0).padStart(7, ' ')} docs${queueSummaryResponse.stats.totalPages.toFixed(0).padStart(8, ' ')} pages\n`
+
+  return txt
+}

--- a/client/utilities/CurrQstats-txt.ts
+++ b/client/utilities/CurrQstats-txt.ts
@@ -1,6 +1,6 @@
-import type { ApiClient } from '~/generated/red-client'
-import type { TestHelperResponses } from './CurrQstats.txt.test'
 import { padStart } from 'lodash-es'
+import type { TestHelperResponses } from './CurrQstats.txt.test'
+import type { ApiClient } from '~/generated/red-client'
 
 type Props = {
   redApi: ApiClient
@@ -18,11 +18,7 @@ ${TABLE_OFFSET}                  docs          pages        in state      in sta
 }
 
 export const renderCurrQstatsDotTxt = async (
-  {
-    // FIXME:
-    // Use redApi when the API is available
-    // redApi,
-  }: Props
+  _props: Props
 ): Promise<string> => {
   let txt = getHeader()
 

--- a/client/utilities/CurrQstats.txt
+++ b/client/utilities/CurrQstats.txt
@@ -1,0 +1,19 @@
+#### RFC Editor Queue Summary:  2025-01-14 ####
+
+    State             total #       total #      Median Wks    Average Wks
+                      docs          pages        in state      in state
+    EDIT                   68           2550            5.6            7.6
+    RFC-EDITOR              5            161            0.9            1.2
+    AUTH48                 29           1004            3.7            7.4
+    AUTH48-DONE             3             35            0.7            0.7
+    AUTH                    0              0            0.0            0.0
+    IANA                    0              0            0.0            0.0
+    IESG                    0              0            0.0            0.0
+    REF                     1             57            0.0            1.0
+    MISSREF(1G)            18            600           51.5           57.2
+    MISSREF(2G)             6            401           87.8           85.3
+    MISSREF(3G)             1             29            0.0           85.7
+    TI                      0              0            0.0            0.0
+
+
+Totals:    131 docs    4837 pages

--- a/client/utilities/CurrQstats.txt.test.ts
+++ b/client/utilities/CurrQstats.txt.test.ts
@@ -3,8 +3,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { vi, test, expect } from 'vitest'
 import { PRIVATE_API_URL } from './url'
-import { ApiClient } from '~/generated/red-client'
 import { renderCurrQstatsDotTxt } from './CurrQstats-txt'
+import { ApiClient } from '~/generated/red-client'
 
 const currQStatsTxt = fs
   .readFileSync(path.join(import.meta.dirname, 'CurrQstats.txt'), 'utf-8')

--- a/client/utilities/CurrQstats.txt.test.ts
+++ b/client/utilities/CurrQstats.txt.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment nuxt
+import fs from 'node:fs'
+import path from 'node:path'
+import { vi, test, expect } from 'vitest'
+import { PRIVATE_API_URL } from './url'
+import { ApiClient } from '~/generated/red-client'
+import { renderCurrQstatsDotTxt } from './CurrQstats-txt'
+
+const currQStatsTxt = fs
+  .readFileSync(path.join(import.meta.dirname, 'CurrQstats.txt'), 'utf-8')
+  .toString()
+
+// FIXME: actually use an API
+export type TestHelperResponses = {
+  queueSummaryResponse: {
+    results: {
+      state: string
+      totalDocs: number
+      totalPages: number
+      medianWeeksInState: number
+      averageWeeksInState: number
+    }[]
+    stats: {
+      totalDocs: number
+      totalPages: number
+    }
+  }
+}
+
+const testHelper = async (): Promise<string> => {
+  const redApiMock = new ApiClient({ baseUrl: PRIVATE_API_URL })
+
+  /*
+    FIXME: update when API is available
+    redApiMock.red.currQstatsAPI = () =>
+      new Promise((resolve) => { })
+    */
+
+  return renderCurrQstatsDotTxt({
+    redApi: redApiMock
+  })
+}
+
+test('CurrQstats.txt: compare against original rendering', async () => {
+  const date = new Date(2025, 0, 14)
+  vi.setSystemTime(date)
+
+  expect(currQStatsTxt.length).toBeGreaterThan(100)
+
+  const result = await testHelper()
+
+  // test rendering against a wget of the existing CurrQstats.txt
+  expect(result).toEqual(currQStatsTxt)
+})


### PR DESCRIPTION
* Implements a placeholder (with correct formatting and tests) for [`/reports/CurrQstats.txt`](https://www.rfc-editor.org/reports/CurrQstats.txt)

I've added a 'Queue API' request to the list of [API Changes needed](https://github.com/ietf-tools/rfced-www/issues/30)