### PR TITLE
refactor: use runtimeConfig

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -53,6 +53,15 @@ export default defineNuxtConfig({
       }
     }
   },
+  // https://nuxt.com/docs/guide/going-further/runtime-config
+  runtimeConfig: {
+    cfServiceTokenId: '', // NUXT_CF_SERVICE_TOKEN_ID env var
+    cfServiceTokenSecret: '', // NUXT_CF_SERVICE_TOKEN_SECRET env var
+    public: {
+      // These settings are available client-side (others are server-side only)
+      datatrackerBase: 'http://localhost:8000/', // NUXT_PUBLIC_DATATRACKER_BASE env var
+    }
+  },
   // https://nitro.build/config#routerules
   // https://nuxt.com/docs/guide/concepts/rendering#hybrid-rendering
   routeRules: {

--- a/client/server/routes/reports/CurrQstats.txt.ts
+++ b/client/server/routes/reports/CurrQstats.txt.ts
@@ -1,13 +1,12 @@
-import { ApiClient } from '~/generated/red-client'
-import { PRIVATE_API_URL } from '~/utilities/url'
 import { renderCurrQstatsDotTxt } from '~/utilities/CurrQstats-txt'
+import { getRedClient } from '~/utilities/redClientWrappers'
 
 export default defineEventHandler(async (event) => {
   setResponseHeaders(event, {
     'Content-Type': 'text/plain; charset=utf-8'
   })
 
-  const redApi = new ApiClient({ baseUrl: PRIVATE_API_URL })
+  const redApi = getRedClient()
   const result = await renderCurrQstatsDotTxt({
     redApi
   })

--- a/client/utilities/CurrQstats.txt.test.ts
+++ b/client/utilities/CurrQstats.txt.test.ts
@@ -2,9 +2,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { vi, test, expect } from 'vitest'
-import { PRIVATE_API_URL } from './url'
 import { renderCurrQstatsDotTxt } from './CurrQstats-txt'
-import { ApiClient } from '~/generated/red-client'
+import { getRedClient } from '~/utilities/redClientWrappers'
 
 const currQStatsTxt = fs
   .readFileSync(path.join(import.meta.dirname, 'CurrQstats.txt'), 'utf-8')
@@ -28,7 +27,7 @@ export type TestHelperResponses = {
 }
 
 const testHelper = async (): Promise<string> => {
-  const redApiMock = new ApiClient({ baseUrl: PRIVATE_API_URL })
+  const redApiMock = getRedClient()
 
   /*
     FIXME: update when API is available

--- a/client/utilities/redClientWrappers.ts
+++ b/client/utilities/redClientWrappers.ts
@@ -1,9 +1,22 @@
 import { FIXME_getRFCMetadataWithMissingData } from './rfc.mocks'
 import { setTimeoutPromise } from './promises'
-import { PRIVATE_API_URL } from './url'
 import { ApiClient } from '~/generated/red-client'
 
-export const getRedClient = () => new ApiClient({ baseUrl: PRIVATE_API_URL })
+export const getRedClient = () => {
+  const config = useRuntimeConfig()
+  const headers: ApiClient['Config']['headers'] = {}
+  if (config.cfServiceTokenId) {
+    headers['CF-Access-Client-Id'] = config.cfServiceTokenId
+  }
+  if (config.cfServiceTokenSecret) {
+    headers['CF-Access-Client-Secret'] = config.cfServiceTokenSecret
+  }
+  console.log(config.public.datatrackerBase)
+  return new ApiClient({
+    baseUrl: config.public.datatrackerBase,
+    headers,
+  })
+}
 
 type DocListArg = Parameters<ApiClient['red']['docList']>[0]
 

--- a/client/utilities/redClientWrappers.ts
+++ b/client/utilities/redClientWrappers.ts
@@ -11,7 +11,6 @@ export const getRedClient = () => {
   if (config.cfServiceTokenSecret) {
     headers['CF-Access-Client-Secret'] = config.cfServiceTokenSecret
   }
-  console.log(config.public.datatrackerBase)
   return new ApiClient({
     baseUrl: config.public.datatrackerBase,
     headers,

--- a/client/utilities/url.ts
+++ b/client/utilities/url.ts
@@ -9,9 +9,6 @@ export type MarkdownPaths = keyof typeof ContentMetadata
 export const IETF_PRIVACY_STATEMENT_URL =
   'https://www.ietf.org/privacy-statement/'
 
-// FIXME: get from an environment variable
-export const PRIVATE_API_URL = 'http://localhost:8000/'
-
 export const PUBLIC_SITE = 'https://www.rfc-editor.org'
 
 export const SEARCH_PATH = '/search/' as const


### PR DESCRIPTION
This seems to be _a_ way to get values from the environment into the Nuxt configuration. Not sure if it's the best (and not sure whether the changes to places where `ApiClient` was being explicitly instantiated work as intended with this change). I've tested this by putting values in `.env` and it works as expected as far as changing the API base URL / adding headers to API requests.

Trying to pull the value out of the `runtimeConfig` into the (previously existing) `PRIVATE_API_URL` did not seem to work due to the lifecycle of Nuxt's composables.

Note that `runtimeConfig` puts constraints on the env names (they have to start with `NUXT_`), so if we go this route we'll need to rename the secrets coming from vault. Not a big deal - we could either do that at the source or translate them over somewhere.