### PR TITLE
fix: Nuxt Router links

### DIFF
--- a/client/components/Breadcrumbs.vue
+++ b/client/components/Breadcrumbs.vue
@@ -5,12 +5,12 @@
       :key="index"
       class="inline-block"
     >
-      <a
+      <A
         class="inline-block px-2 py-2 underline rounded hover:bg-gray-200 hover:text-blue-800"
         :href="path.url"
       >
         {{ path.label }}
-      </a>
+      </A>
       <template v-if="index >= 0 && index < props.breadcrumbItems.length - 1">
         <GraphicsChevron
           class="inline-block -rotate-90 text-gray-300"

--- a/client/components/Footer.vue
+++ b/client/components/Footer.vue
@@ -4,26 +4,26 @@
       <div class="flex-1 flex flex-col gap-5 pr-4">
         <p class="text-base">
           rfc-editor.org is maintained by the
-          <a
+          <A
             href="https://www.ietf.org/"
             class="underline text-blue-100 font-semibold md:text-nowrap"
-            >Internet Engineering Task Force</a
+            >Internet Engineering Task Force</A
           >
           and funded by the
-          <a
+          <A
             href="https://www.internetsociety.org/"
             class="underline text-blue-100 font-semibold md:text-nowrap"
           >
             Internet Society
-          </a>
+          </A>
         </p>
         <div class="flex gap-7 items-center mt-2 lg:mt-5">
-          <a href="https://www.ietf.org/" target="_blank">
+          <A href="https://www.ietf.org/">
             <GraphicsIETFLogo width="105" height="60" />
-          </a>
-          <a href="https://www.internetsociety.org/" target="_blank">
+          </A>
+          <A href="https://www.internetsociety.org/">
             <GraphicsInternetSocietyLogo width="112" height="36" />
-          </a>
+          </A>
         </div>
       </div>
       <div class="flex-1 flex flex-col lg:flex-row gap-10 p-3 lg:p-0">
@@ -37,13 +37,13 @@
               :key="childIndex"
               class="text-base"
             >
-              <a
+              <A
                 :href="child.href"
                 :target="!isInternalLink(child.href) ? '_blank' : undefined"
                 class="underline text-white md:text-nowrap"
               >
                 {{ child.label }}
-              </a>
+              </A>
             </li>
           </ul>
         </div>

--- a/client/components/Graphics/HeaderLogos.vue
+++ b/client/components/Graphics/HeaderLogos.vue
@@ -1,5 +1,5 @@
 <template>
-  <a href="/" :class="[props.class, 'pl-5 md:pl-0']">
+  <A href="/" :class="[props.class, 'pl-5 md:pl-0']">
     <img
       :src="LogoMobile"
       class="lg:hidden"
@@ -14,7 +14,7 @@
       width="183"
       height="37"
     />
-  </a>
+  </A>
 </template>
 
 <script setup lang="ts">

--- a/client/components/HeaderNavMobile.vue
+++ b/client/components/HeaderNavMobile.vue
@@ -91,7 +91,7 @@
                             v-for="(level1, level1Index) in level0.children"
                             :key="level1Index"
                           >
-                            <a
+                            <A
                               v-if="level1.href"
                               :href="level1.href"
                               :class="MENU_ITEM_CLASS"
@@ -100,7 +100,7 @@
                                 class="absolute right-0 mt-1 mr-4 size-4 -rotate-90 text-blue-100"
                               />
                               {{ level1.label }}
-                            </a>
+                            </A>
                           </li>
                         </ul>
                       </AccordionItem>

--- a/client/components/IndexSubheader.vue
+++ b/client/components/IndexSubheader.vue
@@ -15,30 +15,30 @@
         The official home of RFCs
       </Heading>
       <div class="self-end lg:text-right">
-        <a
-          href="/what"
+        <A
+          href="/series/rfc/"
           class="rounded text-blue-100 lg:text-white inline-block px-5 py-3 font-bold text-nowrap hover:bg-black"
         >
           What is an RFC?
           <GraphicsChevron class="-rotate-90 w-[16px] inline-block" />
-        </a>
+        </A>
       </div>
     </div>
 
     <div class="lg:w-2/3 xl:w-1/2 mb-4">
-      <p class="hidden leading-6 lg:block pl-5 md:p-0">
+      <p class="hidden leading-6 lg:block pl-5 md:p-0 text-pretty">
         RFCs outline computer networking and Internet foundations, including
-        <a href="/internet-standards">Internet Standards</a> and historical or
+        <A href="/internet-standards">Internet Standards</A> and historical or
         informative content. They are published by the RFC Editor for the
-        <a href="/ietf">
-          <abbr title="Internet Engineering Task Force">IETF</abbr> </a
+        <A href="/ietf">
+          <abbr title="Internet Engineering Task Force">IETF</abbr> </A
         >,
-        <a href="/irtf"
-          ><abbr title="Internet Reserach Task Force">IRTF</abbr></a
+        <A href="/irtf"
+          ><abbr title="Internet Reserach Task Force">IRTF</abbr></A
         >,
-        <a href="/iab"><abbr title="Internet Architecture Board">IAB</abbr></a
+        <A href="/iab"><abbr title="Internet Architecture Board">IAB</abbr></A
         >, and
-        <a href="/ise"><abbr title="Independent Submission Editor">ISE</abbr></a
+        <A href="/ise"><abbr title="Independent Submission Editor">ISE</abbr></A
         >, which collectively form the authoritative source for RFCs
       </p>
       <SearchBox />

--- a/client/components/RFCCard.vue
+++ b/client/components/RFCCard.vue
@@ -41,7 +41,9 @@
         >
           Abstract
         </Heading>
-        <p class="leading-snug text-gray-800 dark:text-gray-300 pb-2">
+        <p
+          class="leading-snug text-gray-800 dark:text-gray-300 pb-2 text-pretty"
+        >
           {{ props.rfc.abstract }}
         </p>
       </div>

--- a/client/components/RFCCardBody.vue
+++ b/client/components/RFCCardBody.vue
@@ -52,7 +52,7 @@
         >
           Abstract
         </Heading>
-        <p class="leading-snug text-gray-800 dark:text-gray-300">
+        <p class="leading-snug text-gray-800 dark:text-gray-300 text-pretty">
           {{ props.rfc.abstract }}
         </p>
       </div>

--- a/client/components/RFCDocumentBody.vue
+++ b/client/components/RFCDocumentBody.vue
@@ -24,7 +24,7 @@
 
   <p
     v-if="props.rfc.abstract"
-    class="px-1 xs:px-0 mb-2 text-base lg:text-xl print:px-0"
+    class="px-1 xs:px-0 mb-2 text-base lg:text-xl print:px-0 text-pretty"
   >
     {{ props.rfc.abstract }}
   </p>
@@ -49,14 +49,14 @@
             <PopoverArrow />
             <p class="leading-6">
               For the definition of <b>Status</b>, see
-              <a :href="infoRfcPathBuilder('rfc2026')">
+              <A :href="infoRfcPathBuilder('rfc2026')">
                 <component :is="formatTitle('rfc2026')" />
-              </a>
+              </A>
             </p>
             <p class="leading-6">
               For the definition of <b>Stream</b>, see
-              <a :href="infoRfcPathBuilder('rfc8729')">
-                <component :is="formatTitle('rfc8729')" /> </a
+              <A :href="infoRfcPathBuilder('rfc8729')">
+                <component :is="formatTitle('rfc8729')" /> </A
               >.
             </p>
           </PopoverContent>
@@ -91,10 +91,10 @@
             .obsoleted_by"
           :key="obsoletedByItemIndex"
         >
-          <a :href="infoRfcPathBuilder(`RFC${obsoletedByItem.id}`)">
+          <A :href="infoRfcPathBuilder(`RFC${obsoletedByItem.id}`)">
             <component :is="formatTitle(`RFC${obsoletedByItem.id}`)" />
             {{ obsoletedByItem.title }}
-          </a>
+          </A>
         </li>
       </ul>
     </div>

--- a/client/components/RFCIndexPage.vue
+++ b/client/components/RFCIndexPage.vue
@@ -13,12 +13,12 @@
         <template v-if="props.rfcNumberLimit !== undefined">
           <template v-if="props.sort === 'ascending'">
             This page shows the first {{ props.rfcNumberLimit }} RFCs published.
-            Click <a :href="RFC_INDEX_ALL_ASCENDING">Show All</a> to get the
+            Click <A :href="RFC_INDEX_ALL_ASCENDING">Show All</A> to get the
             full list (ascending). RFCs are listed in this format:
           </template>
           <template v-else-if="props.sort === 'descending'">
             This page shows the last {{ props.rfcNumberLimit }} RFCs published.
-            Click <a :href="RFC_INDEX_ALL_DESCENDING">Show All</a> to get the
+            Click <A :href="RFC_INDEX_ALL_DESCENDING">Show All</A> to get the
             full list (descending). RFCs are listed in this format:
           </template>
         </template>
@@ -68,18 +68,18 @@
         </li>
         <li>
           The Status field gives the document's current status (see
-          <a :href="infoRfcPathBuilder('RFC2026')">RFC 2026</a> and
-          <a :href="infoRfcPathBuilder('RFC6410')">RFC 6410</a>).
+          <A :href="infoRfcPathBuilder('RFC2026')">RFC 2026</A> and
+          <A :href="infoRfcPathBuilder('RFC6410')">RFC 6410</A>).
         </li>
         <li>
           The Stream field gives the document's stream (see
-          <a :href="infoRfcPathBuilder('RFC4844')">RFC 4844</a>), followed by
+          <A :href="infoRfcPathBuilder('RFC4844')">RFC 4844</A>), followed by
           Area and WG when relevant.
         </li>
         <li>The DOI field gives the Digital Object Identifier.</li>
       </ul>
       <p>
-        See the <a :href="PUBLIC_SITE">RFC Editor Web page</a> for more
+        See the <A :href="PUBLIC_SITE">RFC Editor Web page</A> for more
         information.
       </p>
       <Alert
@@ -98,10 +98,10 @@
       <template v-if="props.rfcNumberLimit !== undefined">
         <p class="pt-4">
           <template v-if="props.sort === 'ascending'">
-            <a :href="RFC_INDEX_ALL_ASCENDING">Show All</a>
+            <A :href="RFC_INDEX_ALL_ASCENDING">Show All</A>
           </template>
           <template v-else-if="props.sort === 'descending'">
-            <a :href="RFC_INDEX_ALL_DESCENDING">Show All</a>
+            <A :href="RFC_INDEX_ALL_DESCENDING">Show All</A>
           </template>
         </p>
       </template>

--- a/client/components/RFCIndexTable.vue
+++ b/client/components/RFCIndexTable.vue
@@ -27,12 +27,12 @@
         :key="rfcRow.number.toString()"
       >
         <td class="text-right align-top p-1">
-          <a
+          <A
             :href="infoRfcPathBuilder(`rfc${rfcRow.number}`)"
             class="font-mono"
           >
             {{ rfcRow.number }}
-          </a>
+          </A>
         </td>
         <td class="p-1 align-top">
           <p>

--- a/client/components/RFCMobileBanner.vue
+++ b/client/components/RFCMobileBanner.vue
@@ -22,10 +22,10 @@
               .obsoleted_by"
             :key="obsoletedByItemIndex"
           >
-            <a :href="infoRfcPathBuilder(`RFC${obsoletedByItem.id}`)">
+            <A :href="infoRfcPathBuilder(`RFC${obsoletedByItem.id}`)">
               <component :is="formatTitle(`RFC${obsoletedByItem.id}`)" />
               {{ obsoletedByItem.title }}
-            </a>
+            </A>
           </li>
         </ul>
       </div>

--- a/client/components/RFCRouterLinkPreview.vue
+++ b/client/components/RFCRouterLinkPreview.vue
@@ -9,7 +9,7 @@
   <div class="pt-1">
     <Tag size="small" :text="tagText" />
   </div>
-  <p class="leading-5 pt-2 text-xs">
+  <p class="leading-5 pt-2 text-xs text-pretty">
     {{ props.rfcJson.abstract }}
   </p>
   <ul v-if="list1" class="text-base text-blue-900 dark:text-white">

--- a/client/components/RFCTabs.vue
+++ b/client/components/RFCTabs.vue
@@ -57,12 +57,12 @@
               :key="authorIndex"
               class="inline"
             >
-              <a
+              <A
                 :href="authorPathBuilder(author)"
                 class="whitespace-nowrap underline inline-block py-0.5 pr-1 mb-0.5"
               >
                 {{ author.name }}
-              </a>
+              </A>
               <template v-if="authorIndex < props.rfc.authors.length - 1">
                 {{ COMMA }}
                 {{ SPACE }}
@@ -119,18 +119,18 @@
       <Heading level="3" class="mt-5 mb-2">Cite this RFC</Heading>
       <ul class="text-sm flex flex-col gap-2">
         <li v-for="(citation, citationIndex) in citations" :key="citationIndex">
-          <a :href="citation.url" class="underline block px-2 -ml-2">
+          <A :href="citation.url" class="underline block px-2 -ml-2">
             {{ citation.title }}
-          </a>
+          </A>
         </li>
       </ul>
 
       <Heading level="3" class="mt-5 mb-2">Formats</Heading>
       <ul class="text-sm flex flex-col gap-2">
         <li v-for="(format, formatIndex) in formats" :key="formatIndex">
-          <a :href="format.url" class="underline block px-2 -ml-2">{{
+          <A :href="format.url" class="underline block px-2 -ml-2">{{
             format.title
-          }}</a>
+          }}</A>
         </li>
       </ul>
     </TabsContent>

--- a/client/components/content/ProseP.vue
+++ b/client/components/content/ProseP.vue
@@ -1,9 +1,9 @@
 <template>
-  <p class="pt-2">
+  <p class="pt-2 text-pretty">
     <slot />
   </p>
 </template>
 
 <script setup lang="ts">
-// Note: No padding below the paragraph, so that this can be close to following lists/tables etc.
+// Note: No padding below the paragraph, so that paragraphs can be close to following sibling lists/tables etc.
 </script>


### PR DESCRIPTION
* swap `<a>` to `<A>` for Nuxt Router links
* use [`text-wrap: pretty`](https://webkit.org/blog/16547/better-typography-with-text-wrap-pretty/) for some blocks of text like abstract