### PR TITLE
chore: valid hrefs

### DIFF
--- a/client/components/A.vue
+++ b/client/components/A.vue
@@ -1,5 +1,8 @@
 <template>
-  <component :is="isInternal ? NuxtLink : 'a'" v-bind="sanitisedAnchorProps">
+  <component
+    :is="isInternal && !isHash && !isMailTo ? NuxtLink : 'a'"
+    v-bind="sanitisedAnchorProps"
+  >
     <slot />
   </component>
 </template>
@@ -8,28 +11,34 @@
 /**
  * An anchor hyperlink that detects whether to use SPA Vue Router or a conventional hyperlink.
  *
+ * If the link is external then target="_blank" and rel="noopener" will be added.
+ *
  * If you want to ALSO detect RFC links and display a preview use AMaybeRFCLink.vue
+ *
+ * If you want to detect valid hrefs use AValidHref.vue
  */
 import { computed } from 'vue'
 import { NuxtLink } from '#components'
 import { EXTERNAL_LINK_REL, TARGET_NEW_WINDOW } from '~/utilities/html'
 import type { AnchorProps } from '~/utilities/html'
-import { isInternalLink, isMailToLink } from '~/utilities/url'
+import { isHashLink, isInternalLink, isMailToLink } from '~/utilities/url'
 
 const props = defineProps<AnchorProps>()
 
 const isInternal = computed(() => isInternalLink(props.href))
 const isMailTo = computed(() => isMailToLink(props.href))
+const isHash = computed(() => isHashLink(props.href))
 
-const sanitisedAnchorProps = computed(() => ({
-  ...props,
-  to: isInternal.value ? props.href : undefined, // copy `href` to `to` for NuxtLink
-  href: isInternal.value ? undefined : props.href, // clobber 'href' with `undefined` when it's a NuxtLink
-  rel:
-    props.rel ??
-    (!isInternal.value && !isMailTo.value ? EXTERNAL_LINK_REL : undefined),
-  target:
-    props.target ??
-    (!isInternal.value && !isMailTo.value ? TARGET_NEW_WINDOW : undefined)
-}))
+const sanitisedAnchorProps = computed(() => {
+  const isNuxtLink = isInternal.value && !isMailTo.value && !isHash.value
+  const isExternalLink = !isInternal.value && !isMailTo.value && !isHash.value
+
+  return {
+    ...props,
+    to: isNuxtLink ? props.href : undefined, // copy `href` to `to` for NuxtLink
+    href: isNuxtLink ? undefined : props.href, // clobber 'href' with `undefined` when it's a NuxtLink
+    rel: isExternalLink ? EXTERNAL_LINK_REL : undefined,
+    target: isExternalLink ? TARGET_NEW_WINDOW : undefined
+  }
+})
 </script>

--- a/client/components/AValidHref.vue
+++ b/client/components/AValidHref.vue
@@ -11,7 +11,7 @@ import type { ValidHrefs } from '~/utilities/url'
 type AnchorPropsWithValidHref = Omit<AnchorProps, 'href'> & { href: ValidHrefs }
 
 /**
- * TypeScript wrapper for A.vue that attempts to detect valid hrefs
+ * TypeScript wrapper for links that attempts to detect invalid/valid hrefs as TypeScript failures
  */
 const props = defineProps<AnchorPropsWithValidHref>()
 </script>

--- a/client/components/AValidHref.vue
+++ b/client/components/AValidHref.vue
@@ -1,0 +1,17 @@
+<template>
+  <AMaybeRFCLink v-bind="props">
+    <slot />
+  </AMaybeRFCLink>
+</template>
+
+<script setup lang="ts">
+import type { AnchorProps } from '~/utilities/html'
+import type { ValidHrefs } from '~/utilities/url'
+
+type AnchorPropsWithValidHref = Omit<AnchorProps, 'href'> & { href: ValidHrefs }
+
+/**
+ * TypeScript wrapper for A.vue that attempts to detect valid hrefs
+ */
+const props = defineProps<AnchorPropsWithValidHref>()
+</script>

--- a/client/components/Footer.vue
+++ b/client/components/Footer.vue
@@ -7,8 +7,8 @@
           <A
             :href="IETF_URL"
             class="underline text-blue-100 font-semibold md:text-nowrap"
-            >Internet Engineering Task Force
-          </A>
+            >Internet Engineering Task Force</A
+          >
           and funded by the
           <A
             :href="INTERNET_SOCIETY_URL"

--- a/client/components/Footer.vue
+++ b/client/components/Footer.vue
@@ -5,23 +5,23 @@
         <p class="text-base">
           rfc-editor.org is maintained by the
           <A
-            href="https://www.ietf.org/"
+            :href="IETF_URL"
             class="underline text-blue-100 font-semibold md:text-nowrap"
-            >Internet Engineering Task Force</A
-          >
+            >Internet Engineering Task Force
+          </A>
           and funded by the
           <A
-            href="https://www.internetsociety.org/"
+            :href="INTERNET_SOCIETY_URL"
             class="underline text-blue-100 font-semibold md:text-nowrap"
           >
             Internet Society
           </A>
         </p>
         <div class="flex gap-7 items-center mt-2 lg:mt-5">
-          <A href="https://www.ietf.org/">
+          <A :href="IETF_URL">
             <GraphicsIETFLogo width="105" height="60" />
           </A>
-          <A href="https://www.internetsociety.org/">
+          <A :href="INTERNET_SOCIETY_URL">
             <GraphicsInternetSocietyLogo width="112" height="36" />
           </A>
         </div>
@@ -37,11 +37,7 @@
               :key="childIndex"
               class="text-base"
             >
-              <A
-                :href="child.href"
-                :target="!isInternalLink(child.href) ? '_blank' : undefined"
-                class="underline text-white md:text-nowrap"
-              >
+              <A :href="child.href" class="underline text-white md:text-nowrap">
                 {{ child.label }}
               </A>
             </li>
@@ -53,6 +49,6 @@
 </template>
 
 <script setup lang="ts">
-import { isInternalLink } from '../utilities/url'
+import { IETF_URL, INTERNET_SOCIETY_URL } from '../utilities/url'
 import { menuData } from './FooterNavData'
 </script>

--- a/client/components/IndexSubheader.vue
+++ b/client/components/IndexSubheader.vue
@@ -1,3 +1,7 @@
+<script setup lang="ts">
+import { IAB_URL, IETF_URL, IRTF_URL } from '~/utilities/url'
+</script>
+
 <template>
   <div class="container mx-auto">
     <div class="absolute pointer-events-none inset-0 overflow-hidden">
@@ -15,31 +19,38 @@
         The official home of RFCs
       </Heading>
       <div class="self-end lg:text-right">
-        <A
+        <AValidHref
           href="/series/rfc/"
           class="rounded text-blue-100 lg:text-white inline-block px-5 py-3 font-bold text-nowrap hover:bg-black"
         >
           What is an RFC?
           <GraphicsChevron class="-rotate-90 w-[16px] inline-block" />
-        </A>
+        </AValidHref>
       </div>
     </div>
 
     <div class="lg:w-2/3 xl:w-1/2 mb-4">
       <p class="hidden leading-6 lg:block pl-5 md:p-0 text-pretty">
         RFCs outline computer networking and Internet foundations, including
-        <A href="/internet-standards">Internet Standards</A> and historical or
-        informative content. They are published by the RFC Editor for the
-        <A href="/ietf">
-          <abbr title="Internet Engineering Task Force">IETF</abbr> </A
-        >,
-        <A href="/irtf"
-          ><abbr title="Internet Reserach Task Force">IRTF</abbr></A
-        >,
-        <A href="/iab"><abbr title="Internet Architecture Board">IAB</abbr></A
-        >, and
-        <A href="/ise"><abbr title="Independent Submission Editor">ISE</abbr></A
-        >, which collectively form the authoritative source for RFCs
+        <AValidHref href="/standards/">Internet Standards</AValidHref>
+        and historical or informative content. They are published by the RFC
+        Editor for the
+        <AValidHref :href="IETF_URL">
+          <abbr title="Internet Engineering Task Force">IETF</abbr>
+        </AValidHref>
+        ,
+        <AValidHref :href="IRTF_URL">
+          <abbr title="Internet Research Task Force">IRTF</abbr>
+        </AValidHref>
+        ,
+        <AValidHref :href="IAB_URL">
+          <abbr title="Internet Architecture Board">IAB</abbr>
+        </AValidHref>
+        , and
+        <AValidHref href="/authors/rfc-independent-submissions/">
+          <abbr title="Independent Submission Editor">ISE</abbr>
+        </AValidHref>
+        , which collectively form the authoritative source for RFCs
       </p>
       <SearchBox />
     </div>

--- a/client/components/RFCTabs.vue
+++ b/client/components/RFCTabs.vue
@@ -128,9 +128,9 @@
       <Heading level="3" class="mt-5 mb-2">Formats</Heading>
       <ul class="text-sm flex flex-col gap-2">
         <li v-for="(format, formatIndex) in formats" :key="formatIndex">
-          <A :href="format.url" class="underline block px-2 -ml-2">{{
-            format.title
-          }}</A>
+          <A :href="format.url" class="underline block px-2 -ml-2">
+            {{ format.title }}
+          </A>
         </li>
       </ul>
     </TabsContent>

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -13,12 +13,9 @@
           </Heading>
           <p class="hidden mt-8 lg:block text-base text-grey-800 pl-5">
             Looking for works in progress? Go to
-            <a
-              href="https://datatracker.ietf.org/"
-              class="text-blue-300 dark:text-blue-100"
-            >
+            <A :href="DATATRACKER_URL" class="text-blue-300 dark:text-blue-100">
               datatracker.ietf.org
-            </a>
+            </A>
           </p>
         </div>
         <div class="grid grid-cols-1 mt-3 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -108,7 +105,11 @@
 </template>
 
 <script setup lang="ts">
-import { SEARCH_API_PATH, searchPathBuilder } from '~/utilities/url'
+import {
+  DATATRACKER_URL,
+  SEARCH_API_PATH,
+  searchPathBuilder
+} from '~/utilities/url'
 
 definePageMeta({
   layout: false

--- a/client/pages/standards.vue
+++ b/client/pages/standards.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <Heading level="1"> Official Internet Protocol Standards </Heading>
+    <p>This page contains the current lists of</p>
+    <ul>
+      <li>Internet Standards</li>
+      <li>
+        Draft Standards [Note: This maturity level was retired by RFC 6410: "Any
+        protocol or service that is currently at the abandoned Draft Standard
+        maturity level will retain that classification, absent explicit
+        actions."]
+      </li>
+      <li>Proposed Standards</li>
+    </ul>
+    <div>TODO</div>
+  </div>
+</template>
+
+<script setup lang="tsx">
+// TODO: https://www.rfc-editor.org/standards
+// so like a search result of STDs with the current page's  RFC Editor header
+</script>

--- a/client/utilities/url.test.ts
+++ b/client/utilities/url.test.ts
@@ -8,16 +8,17 @@ import {
   isExternalLink,
   isInternalLink,
   isMailToLink,
-  parseMaybeRfcLink
+  parseMaybeRfcLink,
+  isHashLink
 } from './url'
+import type { ValidHrefs } from './url'
+
+// @ts-expect-error If this doesn't fail it implies that ValidHrefs has become overly broad ie a `string` type which is a mistake
+const _HrefThatShouldFail = '/href-that-should-fail/' satisfies ValidHrefs
 
 test('rfcCitePathBuilder: txt', () => {
-  expect(rfcCitePathBuilder('rfc9000', 'txt')).toEqual(
-    'https://www.rfc-editor.org/refs/rfc9000.txt'
-  )
-  expect(rfcCitePathBuilder('RFC9000', 'txt')).toEqual(
-    'https://www.rfc-editor.org/refs/rfc9000.txt'
-  )
+  expect(rfcCitePathBuilder('rfc9000', 'txt')).toEqual('/refs/rfc9000.txt')
+  expect(rfcCitePathBuilder('RFC9000', 'txt')).toEqual('/refs/rfc9000.txt')
 })
 
 test('rfcCitePathBuilder: xml', () => {
@@ -39,12 +40,8 @@ test('rfcCitePathBuilder: bibTeX', () => {
 })
 
 test('rfcFormatPathBuilder: html', () => {
-  expect(rfcFormatPathBuilder('rfc9000', 'html')).toEqual(
-    'https://www.rfc-editor.org/rfc/rfc9000.html'
-  )
-  expect(rfcFormatPathBuilder('RFC9000', 'html')).toEqual(
-    'https://www.rfc-editor.org/rfc/rfc9000.html'
-  )
+  expect(rfcFormatPathBuilder('rfc9000', 'html')).toEqual('/rfc/rfc9000.html')
+  expect(rfcFormatPathBuilder('RFC9000', 'html')).toEqual('/rfc/rfc9000.html')
 })
 
 test('textToAnchorId', () => {
@@ -94,6 +91,24 @@ test('isMailToLink', () => {
   ).toEqual(false)
 
   expect(isMailToLink('mailto:user@example.com')).toEqual(true)
+})
+
+test('isHashLink', () => {
+  expect(isHashLink('#something')).toEqual(true)
+
+  expect(
+    isHashLink(
+      // leading space, should not match
+      ' #something'
+    )
+  ).toEqual(false)
+
+  expect(isHashLink(undefined)).toEqual(false)
+  expect(isHashLink('/something')).toEqual(false)
+  expect(isHashLink('http://')).toEqual(false)
+  expect(isHashLink('https://')).toEqual(false)
+  expect(isHashLink(IETF_PRIVACY_STATEMENT_URL)).toEqual(false)
+  expect(isHashLink('mailto:user@example.com')).toEqual(false)
 })
 
 test('parseMaybeRfcLink', () => {

--- a/client/utilities/url.ts
+++ b/client/utilities/url.ts
@@ -6,20 +6,59 @@ import type { SearchParams } from '~/stores/search'
 
 export type MarkdownPaths = keyof typeof ContentMetadata
 
+export type ValidHrefs =
+  | `https://${string}`
+  | `mailto:${string}`
+  | typeof HOME_PATH
+  | typeof RFC_INDEX_ALL_ASCENDING
+  | typeof RFC_INDEX_100_ASCENDING
+  | typeof RFC_INDEX_ALL_DESCENDING
+  | typeof RFC_INDEX_100_DESCENDING
+  | typeof STANDARDS_PATH
+  | ReturnType<typeof markdownPathBuilder>
+  | ReturnType<typeof searchPathBuilder>
+  | ReturnType<typeof refsRefTxtPathBuilder>
+  | ReturnType<typeof infoRfcPathBuilder>
+  | ReturnType<typeof rfcJSONPathBuilder>
+  | ReturnType<typeof rfcPathBuilder>
+  | ReturnType<typeof rfcFormatPathBuilder>
+
+export const HOME_PATH = '/'
+
 export const IETF_PRIVACY_STATEMENT_URL =
   'https://www.ietf.org/privacy-statement/'
 
 export const PUBLIC_SITE = 'https://www.rfc-editor.org'
 
+export const DATATRACKER_URL = 'https://datatracker.ietf.org/'
+
+export const IETF_URL = 'https://www.ietf.org/'
+
+export const IRTF_URL = 'https://www.irtf.org/'
+
+export const IAB_URL = 'https://www.iab.org/'
+
+export const INTERNET_SOCIETY_URL = 'https://www.internetsociety.org/'
+
 export const SEARCH_PATH = '/search/' as const
 
 export const SEARCH_API_PATH = '/api/search/' as const
+
+export const RFC_INDEX_ALL_ASCENDING = '/rfc-index/' as const
+
+export const RFC_INDEX_100_ASCENDING = '/rfc-index-100a/' as const
+
+export const RFC_INDEX_ALL_DESCENDING = '/rfc-index2/' as const
+
+export const RFC_INDEX_100_DESCENDING = '/rfc-index-100d/' as const
+
+export const STANDARDS_PATH = '/standards/' as const
 
 type SearchKeys = keyof SearchParams
 
 export const searchPathBuilder = (
   searchParams: Partial<SearchParams>
-): string => {
+): `${typeof SEARCH_PATH}${string}` => {
   const hasParams = Object.values(searchParams).join('').trim().length > 0
   return `${SEARCH_PATH}${hasParams ? '?' : ''}${
     hasParams ?
@@ -34,38 +73,37 @@ export const searchPathBuilder = (
   }`
 }
 
-export const RFC_INDEX_ALL_ASCENDING = '/rfc-index/' as const
-
-export const RFC_INDEX_100_ASCENDING = '/rfc-index-100a/' as const
-
-export const RFC_INDEX_ALL_DESCENDING = '/rfc-index2/' as const
-
-export const RFC_INDEX_100_DESCENDING = '/rfc-index-100d/' as const
-
-export const refsRefTxtPathBuilder = (rfcId: string) => {
+export const refsRefTxtPathBuilder = (
+  rfcId: string
+): `/refs/ref${string}.txt` => {
   const rfcParts = parseRFCId(rfcId)
 
   return `/refs/ref${rfcParts.number}.txt`
 }
 
-export const infoRfcPathBuilder = (rfcId: string) => {
+export const infoRfcPathBuilder = (
+  rfcId: string
+): `/info/${string}${string}/` => {
   const rfcParts = parseRFCId(rfcId)
 
   return `/info/${rfcParts.type.toLowerCase()}${rfcParts.number}/`
 }
 
-export const rfcJSONPathBuilder = (rfcId: string) => {
+export const rfcJSONPathBuilder = (
+  rfcId: string
+): `/api/v1/rfc/rfc${string}.json` => {
   const rfcParts = parseRFCId(rfcId)
 
   return `/api/v1/rfc/rfc${rfcParts.number}.json`
 }
 
 /**
- * This is only used for TS to check valid markdown paths. It's just an identity function.
+ * This is only used for TS to check valid markdown paths.
+ * It's just an identity function.
  */
 export const markdownPathBuilder = (markdownPath: MarkdownPaths) => markdownPath
 
-export const rfcPathBuilder = (rfcId: string) => {
+export const rfcPathBuilder = (rfcId: string): `/rfc/${string}${string}/` => {
   const rfcParts = parseRFCId(rfcId)
 
   return `/rfc/${rfcParts.type.toLowerCase()}${rfcParts.number}/`
@@ -74,12 +112,12 @@ export const rfcPathBuilder = (rfcId: string) => {
 export const rfcCitePathBuilder = (
   rfcId: string,
   format: 'txt' | 'bibTeX' | 'xml'
-): string => {
+): `https://${string}` | `/refs/${string}.txt` => {
   const parsedRfcId = parseRFCId(rfcId)
 
   switch (format) {
     case 'txt':
-      return `${PUBLIC_SITE}/refs/${parsedRfcId.type.toLowerCase()}${parsedRfcId.number}.txt`
+      return `/refs/${parsedRfcId.type.toLowerCase()}${parsedRfcId.number}.txt`
     case 'xml':
       return `https://bib.ietf.org/public/rfc/bibxml/reference.${parsedRfcId.type.toUpperCase()}.${parsedRfcId.number}.xml`
     case 'bibTeX':
@@ -87,12 +125,15 @@ export const rfcCitePathBuilder = (
   }
 }
 
-export const rfcFormatPathBuilder = (rfcId: string, format: 'html'): string => {
+export const rfcFormatPathBuilder = (
+  rfcId: string,
+  format: 'html'
+): `/rfc/${string}${string}.html` => {
   const parsedRfcId = parseRFCId(rfcId)
 
   switch (format) {
     case 'html':
-      return `${PUBLIC_SITE}/rfc/${parsedRfcId.type.toLowerCase()}${parsedRfcId.number}.html`
+      return `/rfc/${parsedRfcId.type.toLowerCase()}${parsedRfcId.number}.html`
   }
 }
 
@@ -118,6 +159,8 @@ export const isExternalLink = (href?: string): boolean => {
 
 export const isInternalLink = (href?: string): boolean => !isExternalLink(href)
 
+export const isHashLink = (href?: string): boolean => !!href?.startsWith('#')
+
 /**
  * Converts arbitrary text into a custom id that is DOMId compliant (ie no whitespace)
  *
@@ -139,6 +182,12 @@ export const textToAnchorId = (text: string): string | undefined => {
 
   return kebabCase(normalized)
 }
+
+/**
+ * Based on the URL of the API detect whether it's prod
+ */
+export const isProdApi = (apiBaseUrl: string): boolean =>
+  !apiBaseUrl.includes('localhost')
 
 export const parseMaybeRfcLink = (
   href?: string


### PR DESCRIPTION
* Adds a link wrapper `AValidHref.vue` that checks `href` for valid links in Vue.
* URL refactoring for (eg) IRTF links as constants
* getRedClient fixes
* `A.vue` tidy ups

Note: doesn't work for markdown files because those are compiled to HTML.